### PR TITLE
Add fix for Craft CMS 3.7.46 PHP 8 update with translatedOptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "craft-plugin",
     "require": {
         "php": "^8.0",
-        "craftcms/cms": "^3.7 || ^4.0"
+        "craftcms/cms": "^3.7.46 || ^4.0"
     },
     "license": "MIT",
     "autoload": {

--- a/src/fields/PicktureField.php
+++ b/src/fields/PicktureField.php
@@ -90,7 +90,7 @@ class PicktureField extends \craft\fields\RadioButtons
         ]);
     }
 
-    protected function translatedOptions(): array
+    protected function translatedOptions(bool $encode = false): array
     {
         $translatedOptions = [];
 


### PR DESCRIPTION
Craft make a change to the translatedOptions function on BaseOptionsField for PHP 8 improvements. This pulls in the same update to the PicktureField so it doesn't throw an error. This change will lock this version to Craft 3.7.46 and above.