### PR TITLE
Removed declaration for $value

### DIFF
--- a/src/fields/PicktureField.php
+++ b/src/fields/PicktureField.php
@@ -115,7 +115,7 @@ class PicktureField extends \craft\fields\RadioButtons
         return $translatedOptions;
     }
 
-    protected function inputHtml(mixed $value, ElementInterface $element = null): string
+    protected function inputHtml($value, ElementInterface $element = null): string
     {
         Craft::$app->getView()->registerAssetBundle(PicktureAsset::class);
 


### PR DESCRIPTION
The craft docs tell us that the plugin is compatible with craft 3. (3.7.57)
But it throws an error.  This is the solution. I din't test craft 4 with this fix.

Declaration of Imarc\Pickture\fields\PicktureField::inputHtml(Imarc\Pickture\fields\mixed $value, ?craft\base\ElementInterface $element = NULL): string should be compatible with craft\fields\RadioButtons::inputHtml($value, ?craft\base\ElementInterface $element = NULL): string

