### PR TITLE
fix: craft 4.4 compatibility 

### DIFF
--- a/src/fields/PicktureField.php
+++ b/src/fields/PicktureField.php
@@ -93,7 +93,7 @@ class PicktureField extends \craft\fields\RadioButtons
         ]);
     }
 
-    protected function translatedOptions(bool $encode = false): array
+    protected function translatedOptions(bool $encode = false, mixed $value = null, ?craft\base\ElementInterface $element = null): array
     {
         $translatedOptions = [];
 


### PR DESCRIPTION
This simple fix should get rid of the error message. It doesn't appear to break anything, but i haven't properly tested it yet.